### PR TITLE
Add docker-compose file and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ docker run --rm -p8000:8000 -p5900:5900 \
 
 *Note: The `:ro` flag in the volume mount (`-v`) makes the password file read-only inside the container for added security.*
 
+### Docker Compose
+
+To simplify running the service you can use `docker compose`:
+
+```bash
+docker compose up
+```
+
+The compose file builds the image, exposes ports `8000` and `5900`, reads environment variables from `.env`, and mounts `vnc_password.txt` if present for the VNC password.
+
 ### VNC Viewer
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+services:
+  server:
+    build: .
+    image: browser-use-mcp-server:latest
+    container_name: browser-use-mcp-server
+    ports:
+      - "8000:8000"
+      - "5900:5900"
+    env_file:
+      - .env
+    volumes:
+      # Optional: mount a file containing VNC password
+      - ./vnc_password.txt:/run/secrets/vnc_password:ro
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add docker-compose.yml to simplify container setup
- document docker compose usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a248df8c8333ac3da171d49b7eef